### PR TITLE
made top/bttm and upload required to submit

### DIFF
--- a/components/forms/AddItemForm.js
+++ b/components/forms/AddItemForm.js
@@ -20,6 +20,7 @@ const initialState = {
 };
 
 export default function ItemForm({ itemObj }) {
+  const [clicked, setClicked] = useState(false);
   const [progress, setProgress] = useState(0);
   const [imgUrl, setImgUrl] = useState('');
   const { user } = useAuth();
@@ -87,6 +88,10 @@ export default function ItemForm({ itemObj }) {
       updateItem(formInput).then(() => {
         handleShow();
       });
+    } else if (!clicked) {
+      window.confirm('Please select TOP or BOTTOM!');
+    } else if (!imgUrl) {
+      window.confirm('Please UPLOAD an image!');
     } else {
       const payload = { ...formInput, uid: user.uid };
       createItem(payload).then(({ name }) => {
@@ -140,7 +145,7 @@ export default function ItemForm({ itemObj }) {
                 id="toggle"
                 name="isTop"
                 type="radio"
-                required
+                onClick={setClicked}
               >
                 <ToggleButton
                   className="styled"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -464,8 +464,8 @@ justify-content: space-between;
 }
 
 .btn-close {
-  --bs-btn-hover-bg: transparent;
-  --bs-btn-hover-border-color: transparent;
+  --bs-btn-hover-bg: transparent!important;
+  --bs-btn-hover-border-color: transparent!important;
 }
 
 #makeover-gif {


### PR DESCRIPTION
## Description
Added logic to onSubmit to catch if user hasn't selected top or bottom, or if they haven't uploaded an image, in which case a confirmation window gives an error message.

## Related Issue
#16 

## Motivation and Context
Fixes issue of items submitted without image or top/bottom category, which created errors

## How Can This Be Tested?
add item form

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
